### PR TITLE
README.md: replace config path /cas/etc by /etc/cas

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,9 @@ Generic CAS maven war overlay to exercise the latest versions of CAS. This overl
 # Requirements
 * JDK 1.7+
 
-# Configuration 
-The `etc` directory contains the configuration files that need to be copied to `/cas/etc`. 
+# Configuration
+
+The `etc` directory contains the configuration files that need to be copied to `/etc/cas`.
 
 Current files are:
 


### PR DESCRIPTION
The following can be found in the `src/main/webapp/WEB-INF/spring-configuration/propertyFileConfigurer.xml` :
```
<util:properties id="casProperties" location="file:/etc/cas/cas.properties" />
```

According to that and the FHS, fix the config path in the README from /cas/etc to /etc/cas
