### PR TITLE
update pom.xml, groupId was missing err maven

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -101,6 +101,7 @@
         </dependency>
 
         <dependency>
+            <groupId>org.jasig.cas</groupId>
             <artifactId>cas-server-support-saml</artifactId>
             <version>${cas.version}</version>
             <scope>runtime</scope>


### PR DESCRIPTION
in pom.xml, groupId is missing for 'cas-server-support-saml', failing the minimal maven run